### PR TITLE
Minor fixes for excludes

### DIFF
--- a/lib/minitest/excludes.rb
+++ b/lib/minitest/excludes.rb
@@ -47,7 +47,7 @@ class MiniTest::Unit::TestCase
     return warn "Method #{self}##{name} is not defined" unless
       method_defined? name
 
-    remove_method name
+    undef_method name
   end
 
   ##
@@ -58,7 +58,7 @@ class MiniTest::Unit::TestCase
       begin
         if name and not name.empty? then
           file = File.join EXCLUDE_DIR, "#{name.gsub(/::/, '/')}.rb"
-          instance_eval File.read file if File.exist? file
+          instance_eval File.read(file), file if File.exist? file
         end
         true
       end


### PR DESCRIPTION
- use undef_method since remove_method does not pick up superclasses

At least one MRI test (ruby/test_file.rb) and others I've seen in the wild include a module to get some of their tests. remove_method will not remove methods from an included module. undef_method works ok.
- add file to excludes instance_eval, for better error reporting

When there's an error in the excludes file, it currently only reports "(eval)", making it difficult to diagnose. This change simply adds the filename to the instance_eval call.
