### PR TITLE
make excludes working with 5.0

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,9 @@
+=== 2.0.1 / 2017-11-17
+
+* 1 major enhancement:
+
+  * Really updated for minitest 5.
+
 === 2.0.0 / 2015-02-02
 
 * 1 major enhancement:
@@ -28,4 +34,3 @@
   * Don't keep using the env var, since bad tests may modify ENV w/o restoring it. (headius)
   * Map X::Y to X/Y.rb for excludes to deal with nested test classes.
   * Remove method instead of generating a skip to avoid setup/teardown overhead.
-

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ Hoe.add_include_dirs "../../minitest/dev/lib"
 Hoe.spec "minitest-excludes" do
   developer "Ryan Davis", "ryand-ruby@zenspider.com"
 
-  dependency "minitest", "~> 4.0"
+  dependency "minitest", "~> 5.0"
 end
 
 # vim: syntax=ruby

--- a/lib/minitest/excludes.rb
+++ b/lib/minitest/excludes.rb
@@ -1,7 +1,7 @@
 require 'minitest/test'
 
 module Minitest::Excludes # :nodoc:
-  VERSION = "2.0.0" # :nodoc:
+  VERSION = "2.0.1" # :nodoc:
 end
 
 ##


### PR DESCRIPTION
seems to have been intended ... but somehow the gemspec's version matcher was kept on ~> 4.0

guess not many use excludes, but we know have a use-case of running and excluding Rails tests ...
and since its using hoe and not a plain .gemspec we would also kindly like to ask for a gem release